### PR TITLE
fix: ref_id will not type-cast strings into numbers

### DIFF
--- a/server/handlers/config/schemas.js
+++ b/server/handlers/config/schemas.js
@@ -3,7 +3,7 @@ const Joi = require('joi');
 const configPostSchema = Joi.object({
   name: Joi.string().required(),
   data: Joi.object().required(),
-  ref_id: Joi.number().integer(),
+  ref_id: Joi.number().integer().strict(),
   ref_uuid: Joi.string().uuid(),
 });
 


### PR DESCRIPTION
* Added .strict() to ref_id within ConfigPostSchema.js and tested within postman 

video: https://www.loom.com/share/b595bbf5379c4800be1bad84732d314d